### PR TITLE
Fixed issue causing "Wrong at_hash" warning message

### DIFF
--- a/src/bundle/oauth.js
+++ b/src/bundle/oauth.js
@@ -907,7 +907,7 @@ var oauth2 = oauth2 || {};
             var leftMostHalf = tokenHash.substr(0, tokenHash.length/2 );
 
             var tokenHashBase64 = $base64.encode(leftMostHalf);
-            var atHash = tokenHashBase64.replace("+", "-").replace("/", "_").replace(/=/g, ""); 
+            var atHash = tokenHashBase64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, ""); 
 
             return (atHash == idClaims.at_hash);
         }

--- a/src/oauth-service.js
+++ b/src/oauth-service.js
@@ -444,7 +444,7 @@ var oauth2 = oauth2 || {};
             var leftMostHalf = tokenHash.substr(0, tokenHash.length/2 );
 
             var tokenHashBase64 = $base64.encode(leftMostHalf);
-            var atHash = tokenHashBase64.replace("+", "-").replace("/", "_").replace(/=/g, ""); 
+            var atHash = tokenHashBase64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, ""); 
 
             return (atHash == idClaims.at_hash);
         }


### PR DESCRIPTION
Fixed issue causing "Wrong at_hash" warning message when atHash contained multiple forward slash or plus.

Please can you include this change and update the npm package.

Thanks
